### PR TITLE
Fix problem with removing all numbers

### DIFF
--- a/src/frontend/containers/SampleForm/state.js
+++ b/src/frontend/containers/SampleForm/state.js
@@ -47,7 +47,7 @@ module.exports = React.createClass({
 
   onTextChange: function (e) {
     const value = e.target.value
-    if (!/^[0-9]+$/.test(value)) { return }
+    if (!/^[0-9]*$/.test(value)) { return }
 
     this.setState({
       text: value


### PR DESCRIPTION
Basing on this bonus task, I think that there is no information that we should not allow a user to remove the whole input:

> bonus round
>
> for bonus points: the text input should only allow numbers. If you try to type a non-numeric character into the input, nothing happens.

And no you are not able to remove the last digit in it. I think this will solve this issue.